### PR TITLE
New domains for 8.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+build
+dist
+*.spec

--- a/RegionChanger.py
+++ b/RegionChanger.py
@@ -10,6 +10,25 @@ import time
 import sys
 
 hosts_path = r"C:\Windows\System32\drivers\etc\hosts"
+regions = {
+    "0": ("Set Default", None),
+    "1": ("N. Virginia", "us-east-1"),
+    "2": ("Ohio", "us-east-2"),
+    "3": ("N. California", "us-west-1"),
+    "4": ("Oregon", "us-west-2"),
+    "5": ("Frankfurt", "eu-central-1"),
+    "6": ("Ireland", "eu-west-1"),
+    "7": ("London", "eu-west-2"),
+    "8": ("South America", "sa-east-1"),
+    "9": ("Asia Pacific (Mumbai)", "ap-south-1"),
+    "10": ("Asia Pacific (Seoul)", "ap-northeast-2"),
+    "11": ("Asia Pacific (Singapore)", "ap-southeast-1"),
+    "12": ("Asia Pacific (Sydney)", "ap-southeast-2"),
+    "13": ("Asia Pacific (Tokyo)", "ap-northeast-1"),
+    "14": ("Asia Pacific (Hong Kong)", "ap-east-1"),
+    "15": ("Canada", "ca-central-1"),
+}
+all_domains = [region[1] for key, region in regions.items() if key not in ["0"]]
 
 def is_admin():
     try:
@@ -50,7 +69,7 @@ def remove_all_overrides():
         # This the traditional pattern used < 8.4.0
         pattern1 = r".*\sgamelift\.[^.]+\.amazonaws\.com$"
         # The .api.aws hostnames were added briefly in 8.4.0, then reverted.
-        # Starting in 8.5.2, tghe
+        # Starting in 8.5.2, the .api.aws seem to be turned on and off intermittently.
         pattern2 = r".*\sgamelift-ping\.[^.]+\.api\.aws$"
         return re.match(pattern1, line) or re.match(pattern2, line)
 
@@ -91,25 +110,6 @@ def get_current_region(regions):
 
 
 def get_user_region_choice():
-    regions = {
-        "0": ("Set Default", None),
-        "1": ("N. Virginia", "us-east-1"),
-        "2": ("Ohio", "us-east-2"),
-        "3": ("N. California", "us-west-1"),
-        "4": ("Oregon", "us-west-2"),
-        "5": ("Frankfurt", "eu-central-1"),
-        "6": ("Ireland", "eu-west-1"),
-        "7": ("London", "eu-west-2"),
-        "8": ("South America", "sa-east-1"),
-        "9": ("Asia Pacific (Mumbai)", "ap-south-1"),
-        "10": ("Asia Pacific (Seoul)", "ap-northeast-2"),
-        "11": ("Asia Pacific (Singapore)", "ap-southeast-1"),
-        "12": ("Asia Pacific (Sydney)", "ap-southeast-2"),
-        "13": ("Asia Pacific (Tokyo)", "ap-northeast-1"),
-        "14": ("Asia Pacific (Hong Kong)", "ap-east-1"),
-        "15": ("Canada", "ca-central-1"),
-    }
-
     print("GitHub: https://github.com/DAMERTON/Dead-by-Daylight-Region-Changer")
     print("-------------------------------------------------------------------")
     print("\nWelcome to the Bloodpoint Farming Region Changer!")
@@ -131,7 +131,7 @@ def get_user_region_choice():
             domains_to_block = [f"gamelift.{region}.amazonaws.com" for region in regions_to_block] + \
                                [f"gamelift-ping.{region}.api.aws" for region in regions_to_block]
 
-            return choice, chosen_domain, domains_to_block, regions
+            return choice, chosen_domain, domains_to_block
         else:
             print("Invalid choice. Please try again.")
 
@@ -147,18 +147,10 @@ if __name__ == "__main__":
         ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, " ".join(sys.argv), None, 1)
         sys.exit()
 
-    all_domains = []
-    first_run = True
-
     while True:
-        if not first_run:
-            clear_console()
-        first_run = False
-        choice, chosen_domain, domains_to_block, regions = get_user_region_choice()
+        choice, chosen_domain, domains_to_block = get_user_region_choice()
 
-        if not all_domains:
-            all_domains = [region[1] for key, region in regions.items() if key not in ["0"]]
-        elif choice == "0":  # Set Default option
+        if choice == "0":  # Set Default option
             print("\nPerforming cleanup...")
             remove_all_overrides()
         else:
@@ -172,3 +164,4 @@ if __name__ == "__main__":
             print(f"\nDone!")
 
         time.sleep(1)  # Wait for 1 second before the next iteration
+        clear_console()

--- a/RegionChanger.py
+++ b/RegionChanger.py
@@ -5,9 +5,11 @@
 # ---------------------------------------------
 import os
 import ctypes
+import re
 import time
 import sys
-import subprocess
+
+hosts_path = r"C:\Windows\System32\drivers\etc\hosts"
 
 def is_admin():
     try:
@@ -15,111 +17,63 @@ def is_admin():
     except:
         return False
 
-def remove_gamelift_ping_entries():
-    hosts_path = r"C:\Windows\System32\drivers\etc\hosts"
-    gamelift_ping_domains = [
-        "gamelift-ping.us-east-1.api.aws",
-        "gamelift-ping.us-east-2.api.aws",
-        "gamelift-ping.us-west-1.api.aws",
-        "gamelift-ping.us-west-2.api.aws",
-        "gamelift-ping.eu-central-1.api.aws",
-        "gamelift-ping.eu-west-1.api.aws",
-        "gamelift-ping.eu-west-2.api.aws",
-        "gamelift-ping.sa-east-1.api.aws",
-        "gamelift-ping.ap-south-1.api.aws",
-        "gamelift-ping.ap-northeast-2.api.aws",
-        "gamelift-ping.ap-southeast-1.api.aws",
-        "gamelift-ping.ap-southeast-2.api.aws",
-        "gamelift-ping.ap-northeast-1.api.aws",
-        "gamelift-ping.ca-central-1.api.aws"
-    ]
-
-    if is_admin():
-        with open(hosts_path, 'r') as hosts_file:
-            lines = hosts_file.readlines()
-
-        # Check if any gamelift-ping entries are present
-        gamelift_entries_found = any(any(domain in line for domain in gamelift_ping_domains) for line in lines)
-
-        if gamelift_entries_found:
-            # Filter out lines containing gamelift-ping domains
-            filtered_lines = [
-                line for line in lines if not any(domain in line for domain in gamelift_ping_domains)
-            ]
-
-            # Remove any trailing blank lines
-            while filtered_lines and filtered_lines[-1].strip() == "":
-                filtered_lines.pop()
-
-            # Ensure exactly one blank line at the end
-            if filtered_lines and filtered_lines[-1].strip() != "":
-                filtered_lines.append("\n")
-
-            with open(hosts_path, 'w') as hosts_file:
-                hosts_file.writelines(filtered_lines)
-
-            print("\nRemoved gamelift-ping entries from the hosts file.")
-    else:
-        print("This script requires administrator privileges. Please run as administrator.")
 
 def add_to_hosts(ip, domains):
-    hosts_path = r"C:\Windows\System32\drivers\etc\hosts"
+    with open(hosts_path, 'r') as hosts_file:
+        lines = hosts_file.readlines()
 
-    if is_admin():
-        with open(hosts_path, 'r') as hosts_file:
-            lines = hosts_file.readlines()
+    with open(hosts_path, 'a') as hosts_file:
+        for domain in domains:
+            line_to_add = f"{ip} {domain}"
+            if line_to_add not in lines:
+                # Ensure a blank line before adding the new block, if needed
+                if lines and not lines[-1].endswith("\n"):
+                    hosts_file.write("\n")  # Add a blank line if the last line is not empty
+                hosts_file.write(line_to_add + "\n")
+                # print(f"Added '{line_to_add}' to the hosts file.")
 
-        with open(hosts_path, 'a') as hosts_file:
-            for domain in domains:
-                line_to_add = f"{ip} {domain}"
-                if line_to_add not in lines:
-                    # Ensure a blank line before adding the new block, if needed
-                    if lines and not lines[-1].endswith("\n"):
-                        hosts_file.write("\n")  # Add a blank line if the last line is not empty
-                    hosts_file.write(line_to_add + "\n")
-                    # print(f"Added '{line_to_add}' to the hosts file.")
+    # Ensure exactly one blank line at the end of the file
+    with open(hosts_path, 'r') as hosts_file:
+        lines = hosts_file.readlines()
 
-        # Ensure exactly one blank line at the end of the file
-        with open(hosts_path, 'r') as hosts_file:
-            lines = hosts_file.readlines()
+    with open(hosts_path, 'w') as hosts_file:
+        hosts_file.writelines([line.rstrip() + "\n" for line in lines])
+        if not lines[-1].strip():  # Check if last line is blank
+            hosts_file.write("\n")  # Add a blank line if the last line is blank
 
-        with open(hosts_path, 'w') as hosts_file:
-            hosts_file.writelines([line.rstrip() + "\n" for line in lines])
-            if not lines[-1].strip():  # Check if last line is blank
-                hosts_file.write("\n")  # Add a blank line if the last line is blank
-    else:
-        print("This script requires administrator privileges. Please run as administrator.")
 
-def remove_from_hosts(domains):
-    hosts_path = r"C:\Windows\System32\drivers\etc\hosts"
+def remove_all_overrides():
+    with open(hosts_path, 'r') as hosts_file:
+        lines = hosts_file.readlines()
 
-    if is_admin():
-        with open(hosts_path, 'r') as hosts_file:
-            lines = hosts_file.readlines()
+    def is_gamelift_line(line):
+        # This the traditional pattern used < 8.4.0
+        pattern1 = r".*\sgamelift\.[^.]+\.amazonaws\.com$"
+        # The .api.aws hostnames were added briefly in 8.4.0, then reverted.
+        # Starting in 8.5.2, tghe
+        pattern2 = r".*\sgamelift-ping\.[^.]+\.api\.aws$"
+        return re.match(pattern1, line) or re.match(pattern2, line)
 
-        # Filter out lines containing domains to remove
-        filtered_lines = [
-            line for line in lines if not any(domain in line for domain in domains)
-        ]
+    # Filter out lines containing domains to remove
+    filtered_lines = [
+        line for line in lines if not is_gamelift_line(line)
+    ]
 
-        # Remove any trailing blank lines
-        while filtered_lines and filtered_lines[-1].strip() == "":
-            filtered_lines.pop()
+    # Remove any trailing blank lines
+    while filtered_lines and filtered_lines[-1].strip() == "":
+        filtered_lines.pop()
 
-        # Ensure exactly one blank line at the end
-        if filtered_lines and filtered_lines[-1].strip() != "":
-            filtered_lines.append("\n")
+    # Ensure exactly one blank line at the end
+    if filtered_lines and filtered_lines[-1].strip() != "":
+        filtered_lines.append("\n")
 
-        with open(hosts_path, 'w') as hosts_file:
-            hosts_file.writelines(filtered_lines)
+    with open(hosts_path, 'w') as hosts_file:
+        hosts_file.writelines(filtered_lines)
 
-        print("\nCleanup completed: Removed domains from the hosts file.")
+    print("\nCleanup completed: Removed domains from the hosts file.")
 
-    else:
-        print("This script requires administrator privileges. Please run as administrator.")
 
 def get_current_region(regions):
-    hosts_path = r"C:\Windows\System32\drivers\etc\hosts"
     with open(hosts_path, 'r') as hosts_file:
         content = hosts_file.read()
 
@@ -135,24 +89,25 @@ def get_current_region(regions):
     else:
         return "Error in analysis"
 
+
 def get_user_region_choice():
     regions = {
-        "1": ("N. Virginia (us-east-1)", "gamelift.us-east-1.amazonaws.com"),
-        "2": ("Ohio (us-east-2)", "gamelift.us-east-2.amazonaws.com"),
-        "3": ("N. California (us-west-1)", "gamelift.us-west-1.amazonaws.com"),
-        "4": ("Oregon (us-west-2)", "gamelift.us-west-2.amazonaws.com"),
-        "5": ("Frankfurt (eu-central-1)", "gamelift.eu-central-1.amazonaws.com"),
-        "6": ("Ireland (eu-west-1)", "gamelift.eu-west-1.amazonaws.com"),
-        "7": ("London (eu-west-2)", "gamelift.eu-west-2.amazonaws.com"),
-        "8": ("South America (sa-east-1)", "gamelift.sa-east-1.amazonaws.com"),
-        "9": ("Asia Pacific (Mumbai) (ap-south-1)", "gamelift.ap-south-1.amazonaws.com"),
-        "10": ("Asia Pacific (Seoul) (ap-northeast-2)", "gamelift.ap-northeast-2.amazonaws.com"),
-        "11": ("Asia Pacific (Singapore) (ap-southeast-1)", "gamelift.ap-southeast-1.amazonaws.com"),
-        "12": ("Asia Pacific (Sydney) (ap-southeast-2)", "gamelift.ap-southeast-2.amazonaws.com"),
-        "13": ("Asia Pacific (Tokyo) (ap-northeast-1)", "gamelift.ap-northeast-1.amazonaws.com"),
-        "14": ("Canada (ca-central-1)", "gamelift.ca-central-1.amazonaws.com"),
-        "15": ("Set Default", None),
-        "16": ("Exit", None)
+        "0": ("Set Default", None),
+        "1": ("N. Virginia", "us-east-1"),
+        "2": ("Ohio", "us-east-2"),
+        "3": ("N. California", "us-west-1"),
+        "4": ("Oregon", "us-west-2"),
+        "5": ("Frankfurt", "eu-central-1"),
+        "6": ("Ireland", "eu-west-1"),
+        "7": ("London", "eu-west-2"),
+        "8": ("South America", "sa-east-1"),
+        "9": ("Asia Pacific (Mumbai)", "ap-south-1"),
+        "10": ("Asia Pacific (Seoul)", "ap-northeast-2"),
+        "11": ("Asia Pacific (Singapore)", "ap-southeast-1"),
+        "12": ("Asia Pacific (Sydney)", "ap-southeast-2"),
+        "13": ("Asia Pacific (Tokyo)", "ap-northeast-1"),
+        "14": ("Asia Pacific (Hong Kong)", "ap-east-1"),
+        "15": ("Canada", "ca-central-1"),
     }
 
     print("GitHub: https://github.com/DAMERTON/Dead-by-Daylight-Region-Changer")
@@ -160,10 +115,8 @@ def get_user_region_choice():
     print("\nWelcome to the Bloodpoint Farming Region Changer!")
     print("Please select a region from the following options:\n")
 
-    for key, (region_name, _) in regions.items():
-        print(f"{key}. {region_name}")
-        if key == "14":  # Add an empty line between options 14 and 15
-            print()
+    for key, (region_name, region_id) in regions.items():
+        print(f"{key}. {region_name} ({region_id})")
 
     current_region = get_current_region(regions)
     print("\n---------------------------------------------------------")
@@ -174,17 +127,18 @@ def get_user_region_choice():
         choice = input("\nEnter the number of your chosen option: ")
         if choice in regions:
             chosen_domain = regions[choice][1]
-            domains_to_block = [region[1] for key, region in regions.items() if key not in ["15", "16"] and region[1] != chosen_domain]
+            regions_to_block = [region[1] for key, region in regions.items() if key not in ["0"] and region[1] != chosen_domain]
+            domains_to_block = [f"gamelift.{region}.amazonaws.com" for region in regions_to_block] + \
+                               [f"gamelift-ping.{region}.api.aws" for region in regions_to_block]
+
             return choice, chosen_domain, domains_to_block, regions
         else:
             print("Invalid choice. Please try again.")
 
+
 def clear_console():
     """Clear the console screen on Windows."""
     os.system('cls')
-
-
-
 
 
 if __name__ == "__main__":
@@ -203,19 +157,14 @@ if __name__ == "__main__":
         choice, chosen_domain, domains_to_block, regions = get_user_region_choice()
 
         if not all_domains:
-            all_domains = [region[1] for key, region in regions.items() if key not in ["15", "16"]]
-        if choice == "16":  # Exit option
-            print("Exiting the script. Goodbye!")
-            break
-        elif choice == "15":  # Set Default option
+            all_domains = [region[1] for key, region in regions.items() if key not in ["0"]]
+        elif choice == "0":  # Set Default option
             print("\nPerforming cleanup...")
-            remove_from_hosts(all_domains)
-            remove_gamelift_ping_entries()
+            remove_all_overrides()
         else:
             # Clean up all previously added domains before adding new ones
             print("\nCleaning up previous entries...")
-            remove_from_hosts(all_domains)
-            remove_gamelift_ping_entries()
+            remove_all_overrides()
 
             ip_address = "0.0.0.0"  # IP address used to block the domains
             print(f"\nSelected region: {regions[choice][0]}")


### PR DESCRIPTION
## Summary
- Add new .aws.api domains.
- Add HK domain.
- "Set Default" changed to option "0".

## Rationale
I caught DBD doing DNS lookups on new *.api.aws gamelift domains rather than the .*amazonaws.com ones it's used in the past. The game client seems to be switching back and forth between the old and new--maybe some server-side feature flag. Seems easiest to just add both.

## Hosts Example
For Tokyo, the hosts file entries look like:
```
0.0.0.0 gamelift.us-east-1.amazonaws.com
0.0.0.0 gamelift.us-east-2.amazonaws.com
0.0.0.0 gamelift.us-west-1.amazonaws.com
0.0.0.0 gamelift.us-west-2.amazonaws.com
0.0.0.0 gamelift.eu-central-1.amazonaws.com
0.0.0.0 gamelift.eu-west-1.amazonaws.com
0.0.0.0 gamelift.eu-west-2.amazonaws.com
0.0.0.0 gamelift.sa-east-1.amazonaws.com
0.0.0.0 gamelift.ap-south-1.amazonaws.com
0.0.0.0 gamelift.ap-northeast-2.amazonaws.com
0.0.0.0 gamelift.ap-southeast-1.amazonaws.com
0.0.0.0 gamelift.ap-southeast-2.amazonaws.com
0.0.0.0 gamelift.ap-east-1.amazonaws.com
0.0.0.0 gamelift.ca-central-1.amazonaws.com
0.0.0.0 gamelift-ping.us-east-1.api.aws
0.0.0.0 gamelift-ping.us-east-2.api.aws
0.0.0.0 gamelift-ping.us-west-1.api.aws
0.0.0.0 gamelift-ping.us-west-2.api.aws
0.0.0.0 gamelift-ping.eu-central-1.api.aws
0.0.0.0 gamelift-ping.eu-west-1.api.aws
0.0.0.0 gamelift-ping.eu-west-2.api.aws
0.0.0.0 gamelift-ping.sa-east-1.api.aws
0.0.0.0 gamelift-ping.ap-south-1.api.aws
0.0.0.0 gamelift-ping.ap-northeast-2.api.aws
0.0.0.0 gamelift-ping.ap-southeast-1.api.aws
0.0.0.0 gamelift-ping.ap-southeast-2.api.aws
0.0.0.0 gamelift-ping.ap-east-1.api.aws
0.0.0.0 gamelift-ping.ca-central-1.api.aws
```

## CLI Example
```
0. Set Default (None)
1. N. Virginia (us-east-1)
2. Ohio (us-east-2)
3. N. California (us-west-1)
4. Oregon (us-west-2)
5. Frankfurt (eu-central-1)
6. Ireland (eu-west-1)
7. London (eu-west-2)
8. South America (sa-east-1)
9. Asia Pacific (Mumbai) (ap-south-1)
10. Asia Pacific (Seoul) (ap-northeast-2)
11. Asia Pacific (Singapore) (ap-southeast-1)
12. Asia Pacific (Sydney) (ap-southeast-2)
13. Asia Pacific (Tokyo) (ap-northeast-1)
14. Asia Pacific (Hong Kong) (ap-east-1)
15. Canada (ca-central-1)

---------------------------------------------------------
Current region: Asia Pacific (Tokyo)
---------------------------------------------------------
```

## Notes
I haven't looked at how the current region detection works with the pair of hostnames. There's probably a bug in the corner cases there, but it seems to be keeping up over the happy path.

@DAMERTON 